### PR TITLE
Fixed correlationId to be conform with the NetworkMessage.schema.json

### DIFF
--- a/packages/oi4-oec-service-conformity-validator/src/index.ts
+++ b/packages/oi4-oec-service-conformity-validator/src/index.ts
@@ -303,7 +303,7 @@ export class ConformityValidator extends EventEmitter {
                 let eRes: number;
                 const schemaResult: ISchemaConformity = await this.checkSchemaConformity(resource, parsedMessage);
                 if (schemaResult.schemaResult) { // Check if the schema validator threw any faults, schemaResult is an indicator for overall faults
-                    if (parsedMessage.CorrelationId === conformityPayload.MessageId) { // Check if the correlationId matches our messageId (according to guideline)
+                    if (parsedMessage.correlationId === conformityPayload.MessageId) { // Check if the correlationId matches our messageId (according to guideline)
                         eRes = EValidity.ok;
                     } else {
                         eRes = EValidity.partial;

--- a/packages/oi4-oec-service-opcua-model/src/model/IOPCUA.ts
+++ b/packages/oi4-oec-service-opcua-model/src/model/IOPCUA.ts
@@ -23,7 +23,7 @@ export interface IOPCUANetworkMessage {
   MessageType: EOPCUAMessageType;
   PublisherId: string; // TODO: string in the format <serviceType>/<appId>, need to add validators
   DataSetClassId: GUID;
-  CorrelationId?: MessageId;
+  correlationId?: MessageId;
   Messages: IOPCUADataSetMessage[]; // TODO: This should be generic (either Messages or MetaData)
 }
 

--- a/packages/oi4-oec-service-opcua-model/src/opcua/OPCUABuilder.ts
+++ b/packages/oi4-oec-service-opcua-model/src/opcua/OPCUABuilder.ts
@@ -114,7 +114,7 @@ export class OPCUABuilder {
       DataSetClassId: dataSetClassId, // TODO: Generate UUID, but not here, make a lookup,
       PublisherId: this.publisherId,
       Messages: opcUaDataPayload,
-      CorrelationId: correlationId,
+      correlationId: correlationId,
     };
     if (this.lastMessageId === opcUaDataMessage.MessageId) {
       opcUaDataMessage.MessageId = `OverFlow${opcUaDataMessage.MessageId}`;


### PR DESCRIPTION
correlationId must be start with a lowercase-letter to be conform with the NetworkMessage.schema.json