### PR TITLE
Use arrow function to call a function from another class

### DIFF
--- a/packages/oi4-oec-service-node/src/Utilities/Helpers/MqttMessageProcessor.ts
+++ b/packages/oi4-oec-service-node/src/Utilities/Helpers/MqttMessageProcessor.ts
@@ -25,8 +25,8 @@ export class MqttMessageProcessor {
 
     constructor(applicationResources: IOI4ApplicationResources, sendMetaData: Function, sendResource: Function, emitter: EventEmitter) {
         this.applicationResources = applicationResources;
-        this.sendMetaData = sendMetaData;
-        this.sendResource = sendResource;
+        this.sendMetaData = (): void => {sendMetaData};
+        this.sendResource = (): void => {sendResource};
         this.emitter = emitter;
     }
 

--- a/packages/oi4-oec-service-node/src/Utilities/Helpers/MqttMessageProcessor.ts
+++ b/packages/oi4-oec-service-node/src/Utilities/Helpers/MqttMessageProcessor.ts
@@ -14,19 +14,22 @@ import {TopicMethods, PayloadTypes} from './Enums';
 import {OI4RegistryManager} from '../../application/OI4RegistryManager';
 import EventEmitter from 'events';
 
+export declare type OnSendResource = (resource: string, messageId: string, subResource: string, filter: string, page: number, perPage: number) => Promise<void>;
+export declare type OnSendMetaData = (cutTopic: string) => Promise<void>;
+
 export class MqttMessageProcessor {
-    private readonly sendMetaData: Function;
-    private readonly sendResource: Function;
+    private readonly sendMetaData: OnSendMetaData;
+    private readonly sendResource: OnSendResource;
     private readonly METADATA = 'metadata';
     private readonly emitter: EventEmitter;
     private readonly DATA = 'data';
 
     private applicationResources: IOI4ApplicationResources;
 
-    constructor(applicationResources: IOI4ApplicationResources, sendMetaData: Function, sendResource: Function, emitter: EventEmitter) {
+    constructor(applicationResources: IOI4ApplicationResources, sendMetaData: OnSendMetaData, sendResource: OnSendResource, emitter: EventEmitter) {
         this.applicationResources = applicationResources;
-        this.sendMetaData = (): void => {sendMetaData};
-        this.sendResource = (): void => {sendResource};
+        this.sendMetaData = sendMetaData;
+        this.sendResource = sendResource;
         this.emitter = emitter;
     }
 
@@ -247,7 +250,7 @@ export class MqttMessageProcessor {
         const status: StatusEvent = new StatusEvent(OI4RegistryManager.getOi4Id(), EOPCUAStatusCode.Good);
 
         this.emitter.emit('setConfig', status);
-        this.sendResource(Resource.CONFIG, config.MessageId, filter);
+        this.sendResource(Resource.CONFIG, config.MessageId, filter, '', 0, 0);
     }
 
     private async executeDelActions(topicInfo: TopicInfo) {

--- a/packages/oi4-oec-service-node/src/Utilities/Helpers/MqttMessageProcessor.ts
+++ b/packages/oi4-oec-service-node/src/Utilities/Helpers/MqttMessageProcessor.ts
@@ -250,7 +250,7 @@ export class MqttMessageProcessor {
         const status: StatusEvent = new StatusEvent(OI4RegistryManager.getOi4Id(), EOPCUAStatusCode.Good);
 
         this.emitter.emit('setConfig', status);
-        this.sendResource(Resource.CONFIG, config.MessageId, filter, '', 0, 0);
+        this.sendResource(Resource.CONFIG, config.MessageId, '', filter, 0, 0); // TODO set subResource
     }
 
     private async executeDelActions(topicInfo: TopicInfo) {

--- a/packages/oi4-oec-service-node/src/application/OI4Application.ts
+++ b/packages/oi4-oec-service-node/src/application/OI4Application.ts
@@ -74,7 +74,11 @@ class OI4Application extends EventEmitter {
         this.clientCallbacksHelper = new ClientCallbacksHelper(this.clientPayloadHelper);
         this.on('setConfig', this.sendEventStatus);
         // eslint-disable-next-line @typescript-eslint/no-empty-function
-        this.mqttMessageProcessor = new MqttMessageProcessor(this.applicationResources, this.sendMetaData, this.sendResource, super.removeListener('', () => {
+        this.mqttMessageProcessor = new MqttMessageProcessor(
+            this.applicationResources,
+            async (cutTopic: string) => {await this.sendMetaData(cutTopic)}, 
+            async (resource: string, messageId: string, subResource: string, filter: string, page: number, perPage: number) => {await this.sendResource(resource, messageId, subResource, filter, page, perPage)},  
+            super.removeListener('', () => {
         }));
 
         this.initClientCallbacks();


### PR DESCRIPTION
Introduced type-safe arguments for the functions passed to the `MqttMessageProcessor` constructor. This exposes that there is a problem in the `MqttMessageProcessor.setConfig()` method (missing subResource). Currently I have added a *TODO* there.

The functions `sendResource` and `sendMetaData` are now passed via arrow functions in the constructor of the `MqttMessageProcessor`. This fixes the exception that I got when calling the `sendResource` method from the `MqttMessageProcessor`:  

```
async sendResource(resource, messageId, subResource, filter, page = 0, perPage = 0) {

    // throws exception: preparePayload type not found
    //
    // the reason is that the this-keyword points to MqttMessageProcessor and a 
    // method MqttMessageProcessor.preparePayload does not exist
    const validatedPayload = await this.preparePayload(resource, subResource, filter);
   ...
}
```
See also https://stackoverflow.com/questions/20279484/how-to-access-the-correct-this-inside-a-callback