### PR TITLE
Fixed loading of mam object

### DIFF
--- a/packages/oi4-oec-service-node/src/application/OI4ApplicationResources.ts
+++ b/packages/oi4-oec-service-node/src/application/OI4ApplicationResources.ts
@@ -109,7 +109,9 @@ class OI4ApplicationResources extends ConfigParser implements IOI4ApplicationRes
 
     private static extractMamFile(path: string): MasterAssetModel {
         if (existsSync(path)) {
-            return JSON.parse(readFileSync(path).toString());
+            const mam = new MasterAssetModel();
+            Object.assign(mam, JSON.parse(readFileSync(path).toString()));
+            return mam;
         }
         return undefined;
     }

--- a/packages/oi4-oec-service-node/src/application/OI4ApplicationResources.ts
+++ b/packages/oi4-oec-service-node/src/application/OI4ApplicationResources.ts
@@ -109,9 +109,7 @@ class OI4ApplicationResources extends ConfigParser implements IOI4ApplicationRes
 
     private static extractMamFile(path: string): MasterAssetModel {
         if (existsSync(path)) {
-            const mam = new MasterAssetModel();
-            Object.assign(mam, JSON.parse(readFileSync(path).toString()));
-            return mam;
+            return MasterAssetModel.clone(JSON.parse(readFileSync(path, 'utf8')));
         }
         return undefined;
     }


### PR DESCRIPTION
The master asset model was loaded in a way that all methods (like `resourceType`) were missing. 
See https://stackoverflow.com/questions/22875636/how-do-i-cast-a-json-object-to-a-typescript-class