### PR TITLE
Fixed topic parsing and filter handling

### DIFF
--- a/packages/oi4-oec-service-node/src/Utilities/Helpers/Types.ts
+++ b/packages/oi4-oec-service-node/src/Utilities/Helpers/Types.ts
@@ -2,7 +2,7 @@ import {IOPCUADataSetMessage, IOPCUANetworkMessage} from '@oi4/oi4-oec-service-o
 
 export type ValidatedFilter = {
     isValid: boolean;
-    dswidFilter: number;
+    filter: string;
 }
 
 export type ValidatedPayload = {
@@ -28,9 +28,6 @@ export type TopicInfo = {
     appId: string;
     method: string;
     resource: string;
-    oi4Id: string;
-    filter?: string;
-    licenseId?: string;
     subResource?: string;
-    topicTag?: string;
+    filter?: string;
 }

--- a/packages/oi4-oec-service-node/src/application/OI4ApplicationResources.ts
+++ b/packages/oi4-oec-service-node/src/application/OI4ApplicationResources.ts
@@ -80,6 +80,8 @@ class OI4ApplicationResources extends ConfigParser implements IOI4ApplicationRes
 
         this.subscriptionList = []
 
+        this.license = []
+
         // Fill both pubList and subList
         for (const resources of this.profile.resource) {
             let resInterval = 0;
@@ -175,6 +177,10 @@ class OI4ApplicationResources extends ConfigParser implements IOI4ApplicationRes
         return this._license;
     }
 
+    private set license(license: License[]) {
+        this._license = license
+    }
+
     getLicense(oi4Id: string, licenseId?: string): License[] {
         if (oi4Id === undefined) {
             return this.license;
@@ -189,11 +195,7 @@ class OI4ApplicationResources extends ConfigParser implements IOI4ApplicationRes
         return this.license.filter((elem: License) => elem.licenseId === licenseId ? elem : null);
     }
 
-    private set license(license) {
-        this._license = license
-    }
-
-    // --- LicenseText ---
+     // --- LicenseText ---
     get licenseText(): Map<string, LicenseText> {
         return this._licenseText;
     }

--- a/packages/oi4-oec-service-node/tests/application/Oi4ApplicationResources.test.ts
+++ b/packages/oi4-oec-service-node/tests/application/Oi4ApplicationResources.test.ts
@@ -77,11 +77,11 @@ describe('Test Oi4ApplicationResources', () => {
     it('If oi4Id undefined all licenses are returned', () => {
         console.log('Wait for it...');
         const license = resources.getLicense(undefined);
-        expect(license).toBe(undefined);
+        expect(license).toHaveLength(0);
     });
 
     it('If oi4Id has a value but licenseId is undefined all licenses are returned', () => {
-        expect(resources.getLicense(resources.oi4Id)).toBe(undefined);
+        expect(resources.getLicense(resources.oi4Id)).toHaveLength(0);
     });
 
 });


### PR DESCRIPTION
The topic parsing and filter handling was not correct according to the OEC development specification 1.0.0. 

* Removed  `oi4Id`, `licenseId` and `topicTag` from the `ValidatedPayload` type. All this information can now be found in the `ValidatePayload.filter` variable.
* `MqttMessageProcessor.extractCommonInfo()` now reads the *subResource* (if available)
* `MqttMessageProcessor.extractResourceSpecificInfo()` now reads the filter information that is different for each resource type.
* Updated `Oi4Application.validateFilter()` to be conform with the OEC development specification 1.0.0. There is no DataSetWriterId filter anymore.
* `Oi4Application.sendPayload` now sets the correct *subResource* and *filter* (if available).
* Updated unit tests