### PR TITLE
Initialize _license with an empty array

### DIFF
--- a/packages/oi4-oec-service-node/src/application/OI4ApplicationResources.ts
+++ b/packages/oi4-oec-service-node/src/application/OI4ApplicationResources.ts
@@ -76,10 +76,9 @@ class OI4ApplicationResources extends ConfigParser implements IOI4ApplicationRes
 
         this.dataLookup = {};
         this.metaDataLookup = {};
-
-        this.publicationList = []
-
-        this.subscriptionList = []
+        this.publicationList = [];
+        this.subscriptionList = [];
+        this._license = [];
 
         // Fill both pubList and subList
         for (const resources of this.profile.resource) {

--- a/packages/oi4-oec-service-node/src/application/OI4ApplicationResources.ts
+++ b/packages/oi4-oec-service-node/src/application/OI4ApplicationResources.ts
@@ -78,7 +78,7 @@ class OI4ApplicationResources extends ConfigParser implements IOI4ApplicationRes
         this.metaDataLookup = {};
         this.publicationList = [];
         this.subscriptionList = [];
-        this._license = [];
+        this.license = [];
 
         // Fill both pubList and subList
         for (const resources of this.profile.resource) {


### PR DESCRIPTION
Added the following line in the constructor to prevent that the `_license` array is not initialized.

`this.license = []`