### PR TITLE
Export topic parser

### DIFF
--- a/packages/oi4-oec-service-node/src/index.ts
+++ b/packages/oi4-oec-service-node/src/index.ts
@@ -7,3 +7,4 @@ export * from './Config/SettingsPaths';
 export {FileLogger} from './Utilities/FileLogger/FileLogger';
 export * from './Utilities/Helpers/TopicParser';
 export {TopicInfo, TopicWrapper} from './Utilities/Helpers/Types';
+export {TopicMethods, getTopicMethod} from './Utilities/Helpers/Enums';

--- a/packages/oi4-oec-service-node/src/index.ts
+++ b/packages/oi4-oec-service-node/src/index.ts
@@ -5,3 +5,5 @@ export * from './application/MqttSettings';
 export * from './application/OI4ApplicationFactory';
 export * from './Config/SettingsPaths';
 export {FileLogger} from './Utilities/FileLogger/FileLogger';
+export * from './Utilities/Helpers/TopicParser';
+export {TopicInfo, TopicWrapper} from './Utilities/Helpers/Types';


### PR DESCRIPTION
Export the TopicParser because this class is useful for other programs (like the Registry).