### PR TITLE
Removed checkPayloadType() method

### DIFF
--- a/packages/oi4-oec-service-opcua-model/src/opcua/OPCUABuilder.ts
+++ b/packages/oi4-oec-service-opcua-model/src/opcua/OPCUABuilder.ts
@@ -289,25 +289,4 @@ export class OPCUABuilder {
       throw `Validation failed with: ${validateErr.message}`
     }
   }
-
-  async checkPayloadType(payload: any): Promise<string> {
-    let payloadMessageValidation = false;
-    try {
-      payloadMessageValidation = await this.jsonValidator.validate('pagination.schema.json', payload);
-    } catch (validateErr) {
-      payloadMessageValidation = false;
-    }
-    if (payloadMessageValidation === true) {
-      return 'pagination';
-    }
-    try {
-      payloadMessageValidation = await this.jsonValidator.validate('locale.schema.json', payload);
-    } catch (validateErr) {
-      payloadMessageValidation = false;
-    }
-    if (payloadMessageValidation === true) {
-      return 'locale';
-    }
-    return 'none';
-  }
 }


### PR DESCRIPTION
The method `checkPayloadType()` has a lot of issues:
* Currently this method does not work at all, because the required schemas *pagination.schema.json* and *locale.schema.json* are not known by the validator. So the validation always fails and the method returns always `none`.
* There exists a *pagination.schema.json* and a *paginationGet.schema.json*. Without context this method cannot know if it shall check the payload of a PUB-message or a GET-message.
* The return type is a string which is not very type-safe.
* The method only checks for two payload types. It is also strange that 'none' is returned in case that the payload is a mam, profile, health etc.
* The method is part of the OPCUABuilder-class and has nothing to do with building of OPC UA messages.

I suggest to delete this method for the above reasons. 