### PR TITLE
Fixed initialisation of ProductInstanceUri

### DIFF
--- a/packages/oi4-oec-service-node/src/application/OI4ApplicationResources.ts
+++ b/packages/oi4-oec-service-node/src/application/OI4ApplicationResources.ts
@@ -32,8 +32,6 @@ class OI4ApplicationResources extends OI4Resource implements IOI4ApplicationReso
     constructor(mamFile = DEFAULT_MAM_FILE) {
         super(OI4ApplicationResources.extractMamFile(mamFile));
 
-        this._mam.ProductInstanceUri = this._mam.getOI4Id()
-
         this.subResources = new Map<string, IOI4Resource>();
 
         this.dataLookup = {};
@@ -44,6 +42,7 @@ class OI4ApplicationResources extends OI4Resource implements IOI4ApplicationReso
         if (existsSync(filePath)) {
             const mam = MasterAssetModel.clone(JSON.parse(readFileSync(filePath, 'utf8')));
             mam.SerialNumber = os.hostname();
+            mam.ProductInstanceUri = mam.getOI4Id()
             return mam;
         }
         throw new Error(`MAM file ${path.resolve(filePath)} does not exist`);


### PR DESCRIPTION
The classes `OI4ApplicationResources` and `OI4Resources` have used different values for `mam.ProductInstanceUri`. This has led to incorrect *PublicationList* and *SubscriptionList* messages.

* Assume the *mam.json* file has the following ProductInstanceUri: `vendor.com/a/b/c`.
* Now the *mam.json* is loaded in the constructor of the `OI4ApplicationResources` class. 
* The constructor of `OI4ApplicationResources` calls the constructor of `OI4Resource`. Within `OI4Resource` the *publicationList* and *subscriptionList* are created by using the oi4Id `vendor.com/a/b/c`. 
* Now the initialization continues in the  constructor of the `OI4ApplicationResources` class. Here the ProductInstanceUri is changed and now contains a different serial number: `vendor.com/a/b/<PCName>`.
