### PR TITLE
Abort sending in case of a know (but not yet implemented) resource

### DIFF
--- a/packages/oi4-oec-service-node/src/application/OI4Application.ts
+++ b/packages/oi4-oec-service-node/src/application/OI4Application.ts
@@ -266,6 +266,13 @@ class OI4Application extends EventEmitter {
                 payloadResult = this.clientPayloadHelper.createConfigSendResourcePayload(this.applicationResources, subResource, filter);
                 break;
             }
+
+            case Resource.REFERENCE_DESIGNATION:
+            case Resource.INTERFACES:
+                LOGGER.log('Resource not implemented yet, abort sending...');
+                return {payload: undefined, abortSending: true};
+                break;
+    
             default: {
                 await this.sendError(`Unknown Resource: ${resource}`);
                 return;


### PR DESCRIPTION
Abort sending when a resource is unknown. (Currently the application crashes because an `undefined` object is returned.)