### PR TITLE
Fixed MQTT topic for published messages

### DIFF
--- a/packages/oi4-oec-service-node/src/Utilities/Helpers/MqttMessageProcessor.ts
+++ b/packages/oi4-oec-service-node/src/Utilities/Helpers/MqttMessageProcessor.ts
@@ -124,7 +124,37 @@ export class MqttMessageProcessor extends EventEmitter implements IMqttMessagePr
             }
         }
 
-        await oi4Application.sendResource(topicInfo.resource, parsedMessage.MessageId, topicInfo.subResource, topicInfo.filter, page, perPage)
+        let subResource = undefined;
+        let filter = undefined;
+        switch (topicInfo.resource)
+        {
+            case Resource.EVENT:
+                subResource = `${topicInfo.category}/${topicInfo.filter}`;
+                break;
+
+            case Resource.LICENSE:
+            case Resource.LICENSE_TEXT:
+                subResource = topicInfo.oi4Id;
+                filter = topicInfo.licenseId;
+                break;
+
+            case Resource.CONFIG:
+                subResource = topicInfo.oi4Id;
+                filter = topicInfo.filter;
+                break;
+
+            case Resource.PUBLICATION_LIST:
+            case Resource.SUBSCRIPTION_LIST:
+                subResource = topicInfo.oi4Id;
+                filter = topicInfo.tag;
+                break;
+
+            default:
+                subResource = topicInfo.oi4Id;
+                break;
+        }
+
+        await oi4Application.sendResource(topicInfo.resource, parsedMessage.MessageId, subResource, filter, page, perPage)
     }
 
     private async executeSetActions(topicInfo: TopicInfo, parsedMessage: IOPCUANetworkMessage, oi4Application: IOI4Application) {

--- a/packages/oi4-oec-service-node/tests/application/OI4Application.test.ts
+++ b/packages/oi4-oec-service-node/tests/application/OI4Application.test.ts
@@ -355,7 +355,7 @@ describe('OI4MessageBus test', () => {
         const onResourceMock = jest.fn((_, cb) => {
             cb(resources.oi4Id, Resource.HEALTH);
             expect(mockSendResource).toHaveBeenCalled();
-            expect(mockSendResource).toHaveBeenCalledWith(expect.stringContaining(Resource.HEALTH), '', resources.oi4Id, resources.oi4Id);
+            expect(mockSendResource).toHaveBeenCalledWith(expect.stringContaining(Resource.HEALTH), '', resources.oi4Id, '');
         });
         // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
         // @ts-ignore


### PR DESCRIPTION
Fixes the MQTT topic for published messages. There was an `undefined` subResource for several messages because the subResource and filter-handling is not fully implemented yet.

Before the bugfix: 
**Request topic::** `oi4/Registry/a/b/c/d/get/profile/a/b/c/d`
**Response topic:**  `oi4/Registry/a/b/c/d/pub/profile/undefined`

After this bugfix: 
**Request topic::** `oi4/Registry/a/b/c/d/get/profile/a/b/c/d`
**Response topic:**  `oi4/Registry/a/b/c/d/pub/profile/a/b/c/d`