### PR TITLE
License Handling Update

### DIFF
--- a/packages/oi4-oec-service-node/src/Utilities/Helpers/ClientPayloadHelper.ts
+++ b/packages/oi4-oec-service-node/src/Utilities/Helpers/ClientPayloadHelper.ts
@@ -71,8 +71,8 @@ export class ClientPayloadHelper {
         for (const license of licenses) {
             payload.push({
                 DataSetWriterId: DataSetWriterIdManager.getDataSetWriterId(license.resourceType(), subResource),
-                filter: licenseId,
-                subResource: license.licenseId,
+                filter: license.licenseId,
+                subResource: subResource ?? applicationResources.oi4Id,
                 Timestamp: new Date().toISOString(),
                 Payload: {components: license.components},
             })

--- a/packages/oi4-oec-service-node/tests/Utilities/Helpers/ClientPayloadHelper.test.ts
+++ b/packages/oi4-oec-service-node/tests/Utilities/Helpers/ClientPayloadHelper.test.ts
@@ -90,6 +90,8 @@ describe('Unit test for ClientPayloadHelper', () => {
         const validatedPayload: ValidatedPayload = clientPayloadHelper.createLicenseSendResourcePayload(mockedOI4ApplicationResources, '2', 'license');
         expect(validatedPayload.abortSending).toBe(false);
         expect(validatedPayload.payload.length).toBe(1);
+        expect(validatedPayload.payload[0].subResource).toBe('2');
+        expect(validatedPayload.payload[0].filter).toBe('1');
     });
 
     function createPublicationMockedPayload(resource: string, datasetWriterId: number, oi4Id: string) {


### PR DESCRIPTION
## ClientPayloadHelper
* Set correct `subResource` and `filter` for license payload

## OPCUABuilder
* Removed optional arguments `filter` and `metaDataVersion` from `buildPaginatedOPCUANetworkMessageArray` method because these arguments make no sense and have introduced wrong behavior. (E.g. the filter argument was applied to all provided DataSetMessages. This means, it has overridden the filter-setting of these messages.)
