### PR TITLE
OPCUABuilder uses max_package_size from broker.json

### DIFF
--- a/packages/oi4-oec-service-conformity-validator/src/index.ts
+++ b/packages/oi4-oec-service-conformity-validator/src/index.ts
@@ -45,9 +45,12 @@ export class ConformityValidator {
 
         const logLevel: ESyslogEventFilter = process.env.OI4_EDGE_EVENT_LEVEL as ESyslogEventFilter | ESyslogEventFilter.warning;
         const publishingLevel = process.env.OI4_EDGE_EVENT_PUBLISHING_LEVEL ? process.env.OI4_EDGE_EVENT_PUBLISHING_LEVEL as ESyslogEventFilter : logLevel;
-
+        
         initializeLogger(true, 'ConformityValidator-App', logLevel, publishingLevel, oi4Id, serviceType, this.conformityClient);
-        this.builder = new OPCUABuilder(oi4Id, serviceType);
+        
+        // Ignore the maximumPackageSize argument of the builder, because we only use the builder to create ".../get/<resource>" messages. 
+        // Such messages cannot be split into smaller messages and shall never exceed the maximum package size.  
+        this.builder = new OPCUABuilder(oi4Id, serviceType); 
     }
 
     /**

--- a/packages/oi4-oec-service-logger/src/Logger.ts
+++ b/packages/oi4-oec-service-logger/src/Logger.ts
@@ -90,6 +90,8 @@ class Logger {
             this._mqttClient = mqttClient;
         }
 
+        // Ignore the maximumPackageSize argument of the builder, because we only use the builder to create messages that contain one event. 
+        // A message with one event cannot be split into smaller messages and shall never exceed the maximum package size.  
         this._builder = new OPCUABuilder(oi4Id, serviceType);
         this._oi4Id = oi4Id;
         this._serviceType = serviceType;

--- a/packages/oi4-oec-service-node/src/application/OI4Application.ts
+++ b/packages/oi4-oec-service-node/src/application/OI4Application.ts
@@ -434,7 +434,8 @@ export class OI4ApplicationBuilder {
         const oi4Id = this.applicationResources.oi4Id;
         const serviceType = this.applicationResources.mam.getServiceType();
         if (this.opcUaBuilder === undefined) {
-            this.opcUaBuilder = new OPCUABuilder(oi4Id, serviceType);
+            const maximumPackageSize: number = this.mqttSettings?.properties?.maximumPacketSize | 262144;
+            this.opcUaBuilder = new OPCUABuilder(oi4Id, serviceType, maximumPackageSize);
         }
         return this.newOI4Application();
     }

--- a/packages/oi4-oec-service-node/src/application/OI4ApplicationFactory.ts
+++ b/packages/oi4-oec-service-node/src/application/OI4ApplicationFactory.ts
@@ -32,6 +32,7 @@ export class OI4ApplicationFactory implements IOI4MessageBusFactory {
     clientPayloadHelper: ClientPayloadHelper;
     clientCallbacksHelper: ClientCallbacksHelper;
     mqttMessageProcessor: MqttMessageProcessor;
+    opcUaBuilder: OPCUABuilder;
 
     private readonly resources: IOI4ApplicationResources;
     private readonly settingsPaths: ISettingsPaths;
@@ -71,12 +72,14 @@ export class OI4ApplicationFactory implements IOI4MessageBusFactory {
             }
         }
 
-        const opcUaBuilder = new OPCUABuilder(this.resources.oi4Id, this.serviceType, maximumPacketSize);
+        if (this.opcUaBuilder === undefined) {
+            this.opcUaBuilder = new OPCUABuilder(this.resources.oi4Id, this.serviceType, maximumPacketSize);
+        }
         this.initCredentials(mqttSettings);
         this.builder = OI4Application.builder()//
             .withApplicationResources(this.resources)//
             .withMqttSettings(mqttSettings)//
-            .withOPCUABuilder(opcUaBuilder)//
+            .withOPCUABuilder(this.opcUaBuilder)//
             .withClientPayloadHelper(this.clientPayloadHelper)//
             .withClientCallbacksHelper(this.clientCallbacksHelper)//
             .withMqttMessageProcessor(this.mqttMessageProcessor)//


### PR DESCRIPTION
Removed access to environment variable `OI4_EDGE_MQTT_MAX_MESSAGE_SIZE` from `OPCUABuilder`. Introduced a new constructor-argument for the maximum message size. Updated  `OI4ApplicationBuilder ` and `OI4ApplicationFactory` so that the maximum message size is now used when creating the `OPCUABuilder`.