### PR TITLE
Oi4Identifier fixes

### DIFF
--- a/packages/oi4-oec-service-node/src/Utilities/Helpers/TopicParser.ts
+++ b/packages/oi4-oec-service-node/src/Utilities/Helpers/TopicParser.ts
@@ -128,7 +128,7 @@ export class TopicParser {
         if (TopicParser.isAtLeastOneStringEmpty([wrapper.topicArray[8], wrapper.topicArray[9], wrapper.topicArray[10], wrapper.topicArray[11]])) {
             throw new Error(`Malformed Oi4Id : ${wrapper.topicInfo.topic}`);
         }
-        wrapper.topicInfo.oi4Id = new Oi4Identifier(wrapper.topicArray[8], wrapper.topicArray[9], wrapper.topicArray[10], wrapper.topicArray[11]);
+        wrapper.topicInfo.oi4Id = new Oi4Identifier(wrapper.topicArray[8], wrapper.topicArray[9], wrapper.topicArray[10], wrapper.topicArray[11], true);
     }
 
     private static extractFilter(wrapper: TopicWrapper) {

--- a/packages/oi4-oec-service-node/src/application/OI4Application.ts
+++ b/packages/oi4-oec-service-node/src/application/OI4Application.ts
@@ -170,14 +170,14 @@ export class OI4Application extends EventEmitter implements IOI4Application {
         }, this.clientHealthHeartbeatInterval); // send all health messages every 60 seconds!
     }
 
-    private resourceChangedCallback(oi4Id: string, resource: Resource) {
+    private resourceChangedCallback(oi4Id: Oi4Identifier, resource: Resource) {
         if (resource === Resource.HEALTH) {
-            this.sendResource(Resource.HEALTH, '', oi4Id, '').then();
+            this.sendResource(Resource.HEALTH, '', oi4Id.toString(), '').then();
         }
     }
 
-    private resourceAddedCallback(oi4Id: string) {
-        this.sendResource(Resource.MAM, '', oi4Id, '').then();
+    private resourceAddedCallback(oi4Id: Oi4Identifier) {
+        this.sendResource(Resource.MAM, '', oi4Id.toString(), '').then();
     }
 
     // GET SECTION ----------------//

--- a/packages/oi4-oec-service-node/src/application/OI4ApplicationResources.ts
+++ b/packages/oi4-oec-service-node/src/application/OI4ApplicationResources.ts
@@ -85,7 +85,7 @@ class OI4ApplicationResources extends OI4Resource implements IOI4ApplicationReso
     }
 
     public getMasterAssetModel(oi4Id: Oi4Identifier): MasterAssetModel {
-        if(oi4Id === this.oi4Id) {
+        if(oi4Id.equals(this.oi4Id)) {
             return this.mam;
         }
         return this.subResources.get(oi4Id.toString()).mam;

--- a/packages/oi4-oec-service-node/tests/application/OI4Application.test.ts
+++ b/packages/oi4-oec-service-node/tests/application/OI4Application.test.ts
@@ -358,7 +358,7 @@ describe('OI4MessageBus test', () => {
         const onResourceMock = jest.fn((_, cb) => {
             cb(resources.oi4Id, Resource.HEALTH);
             expect(mockSendResource).toHaveBeenCalled();
-            expect(mockSendResource).toHaveBeenCalledWith(expect.stringContaining(Resource.HEALTH), '', resources.oi4Id, '');
+            expect(mockSendResource).toHaveBeenCalledWith(expect.stringContaining(Resource.HEALTH), '', resources.oi4Id.toString(), '');
         });
         // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
         // @ts-ignore

--- a/packages/oi4-oec-service-opcua-model/src/model/Oi4Identifier.ts
+++ b/packages/oi4-oec-service-opcua-model/src/model/Oi4Identifier.ts
@@ -4,11 +4,11 @@ export class Oi4Identifier {
     productCode: string;
     serialNumber: string;
 
-    constructor(manufacturerUri: string, model: string, productCode: string, serialNumber: string) {
+    constructor(manufacturerUri: string, model: string, productCode: string, serialNumber: string, decodeArguments = false) {
         this.manufacturerUri = manufacturerUri;
-        this.model = model;
-        this.productCode = productCode;
-        this.serialNumber = serialNumber;
+        this.model = decodeArguments ? decodeURIComponent(model) : model;
+        this.productCode = decodeArguments ? decodeURIComponent(productCode) : productCode;
+        this.serialNumber = decodeArguments ? decodeURIComponent(serialNumber) : serialNumber;
     }
 
     toString(): string {

--- a/packages/oi4-oec-service-opcua-model/src/model/Oi4Identifier.ts
+++ b/packages/oi4-oec-service-opcua-model/src/model/Oi4Identifier.ts
@@ -20,7 +20,7 @@ export class Oi4Identifier {
         if (oi4IdParts.length !== 4) {
             throw new Error(`Invalid OI4 identifier: ${oi4Id}`);
         }
-        return new Oi4Identifier(oi4IdParts[0], decodeURIComponent(oi4IdParts[1]), decodeURIComponent(oi4IdParts[2]), decodeURIComponent(oi4IdParts[3]));
+        return new Oi4Identifier(oi4IdParts[0], oi4IdParts[1], oi4IdParts[2], oi4IdParts[3], true);
     }
 
     equals(other: Oi4Identifier): boolean {

--- a/packages/oi4-oec-service-opcua-model/src/model/Oi4Identifier.ts
+++ b/packages/oi4-oec-service-opcua-model/src/model/Oi4Identifier.ts
@@ -20,7 +20,7 @@ export class Oi4Identifier {
         if (oi4IdParts.length !== 4) {
             throw new Error(`Invalid OI4 identifier: ${oi4Id}`);
         }
-        return new Oi4Identifier(oi4IdParts[0], oi4IdParts[1], oi4IdParts[2], oi4IdParts[3]);
+        return new Oi4Identifier(oi4IdParts[0], decodeURIComponent(oi4IdParts[1]), decodeURIComponent(oi4IdParts[2]), decodeURIComponent(oi4IdParts[3]));
     }
 
     equals(other: Oi4Identifier): boolean {

--- a/packages/oi4-oec-service-opcua-model/test/model/Oi4Identifier.test.ts
+++ b/packages/oi4-oec-service-opcua-model/test/model/Oi4Identifier.test.ts
@@ -31,4 +31,12 @@ describe('Unit test for Oi4Identifier', () => {
 
         expect(oi4Identifier1.equals(undefined)).toBe(false);
     });
+
+    it('Check Oi4Identifier with special characters', ()=> {
+        const oi4Identifier1 = new Oi4Identifier('acme.com', 'model 1', 'product&Code ', 'serial+Number');
+        const oi4IdentfierString = oi4Identifier1.toString();
+        const oi4Identifier2 = Oi4Identifier.fromString(oi4IdentfierString);
+
+        expect(oi4Identifier1.equals(oi4Identifier2)).toBe(true);
+    })
 });


### PR DESCRIPTION
## Oi4Application 
* Fixed wrong argument types in callback methods: The argument has now the type `Oi4Identifier` and not the type `string`.

## Oi4ApplicationResource
* Fixed wrong equality check for MAMs

## Oi4Identifer
* `fromString` method should consider that the string is URL encoded. 