### PR TITLE
Cfz/resource fix

### DIFF
--- a/packages/oi4-oec-service-node/src/Utilities/Helpers/ClientPayloadHelper.ts
+++ b/packages/oi4-oec-service-node/src/Utilities/Helpers/ClientPayloadHelper.ts
@@ -162,10 +162,10 @@ export class ClientPayloadHelper {
         // filter result
         let config: IOPCUADataSetMessage | undefined;
         const oi4IdString = oi4Id.toString();
-        if (applicationResources.oi4Id == oi4Id) {
+        if (applicationResources.oi4Id.equals(oi4Id)) {
             config = createDataSetMessage(applicationResources.config, applicationResources.oi4Id, filter);
         } else if (applicationResources.subResources.has(oi4IdString)) {
-            config = createDataSetMessage(applicationResources.subResources.get(oi4Id.toString()).config, oi4Id, filter);
+            config = createDataSetMessage(applicationResources.subResources.get(oi4IdString).config, oi4Id, filter);
         }
 
         const messages: IOPCUADataSetMessage[] = config ? [config] : [];

--- a/packages/oi4-oec-service-node/src/application/OI4ApplicationResources.ts
+++ b/packages/oi4-oec-service-node/src/application/OI4ApplicationResources.ts
@@ -9,6 +9,7 @@ import {
     RTLicense,
     SubscriptionList,
     SubscriptionListConfig,
+    License
 } from '@oi4/oi4-oec-service-model';
 
 import {
@@ -99,7 +100,24 @@ class OI4ApplicationResources extends OI4Resource implements IOI4ApplicationReso
         return this.subResources.get(oi4Id.toString())?.health;
     }
 
-    hasSubResource(oi4Id: Oi4Identifier) {
+    getLicense(oi4Id: Oi4Identifier, licenseId?: string): License[] {
+        if (oi4Id === undefined) {
+            return this.license;
+        } 
+        
+        const license = oi4Id.equals(this.oi4Id) ? this.license : this.subResources.get(oi4Id.toString())?.license;
+        if (license === undefined) {
+            return [];
+        }
+
+        if (licenseId === undefined) {
+            return license;
+        }
+
+        return license.filter((elem: License) => elem.licenseId === licenseId ? elem : null);
+    }
+
+    hasSubResource(oi4Id: Oi4Identifier): boolean {
         return this.subResources.has(oi4Id.toString());
     }
 

--- a/packages/oi4-oec-service-node/src/application/OI4Resource.ts
+++ b/packages/oi4-oec-service-node/src/application/OI4Resource.ts
@@ -94,20 +94,6 @@ export class OI4Resource extends EventEmitter implements IOI4Resource {
         return this._license;
     }
 
-    getLicense(oi4Id: Oi4Identifier, licenseId?: string): License[] {
-        if (oi4Id === undefined) {
-            return this.license;
-        } else if (oi4Id.equals(this.oi4Id)) {
-            throw new Error('Sub resources not yet implemented');
-        }
-
-        if (licenseId === undefined) {
-            return this.license;
-        }
-
-        return this.license.filter((elem: License) => elem.licenseId === licenseId ? elem : null);
-    }
-
     private set license(license) {
         this._license = license
     }

--- a/packages/oi4-oec-service-node/tests/application/Oi4ApplicationResources.test.ts
+++ b/packages/oi4-oec-service-node/tests/application/Oi4ApplicationResources.test.ts
@@ -68,8 +68,8 @@ describe('Test Oi4ApplicationResources', () => {
         expect(subResources.next().value).toEqual(value03);
     });
 
-    it('If oi4Id not valid then error is thrown', () => {
-        expect(() => resources.getLicense(resources.oi4Id)).toThrow('Sub resources not yet implemented');
+    it('If oi4Id not valid then an empty list is returned', () => {
+        expect(resources.getLicense(resources.oi4Id)).toStrictEqual([]);
     });
 
     it('If oi4Id undefined all licenses are returned', () => {


### PR DESCRIPTION
## ClientPayloadHelper
* fixed wrong equality-check for Oi4Identifier

## Oi4ApplicationResources
* Fixed: `getLicense` has thrown an exception when the main license was requested. Added support for sub-resources.