### PR TITLE
Fixed set/config behavior

### DIFF
--- a/packages/oi4-oec-service-model/src/model/IOI4ApplicationResources.ts
+++ b/packages/oi4-oec-service-model/src/model/IOI4ApplicationResources.ts
@@ -19,7 +19,7 @@ export interface IOI4ApplicationResources extends IOI4Resource {
 
     getMasterAssetModel(oi4Id: Oi4Identifier): MasterAssetModel;
 
-    getSubResource(oi4Id?: Oi4Identifier): IOI4Resource | IterableIterator<IOI4Resource>
+    getSubResource(oi4Id?: Oi4Identifier): IOI4Resource | IterableIterator<IOI4Resource>;
 
     getHealth(oi4Id: Oi4Identifier): Health;
 
@@ -29,9 +29,10 @@ export interface IOI4ApplicationResources extends IOI4Resource {
 
     getPublicationList(oi4Id: Oi4Identifier, resourceType?: Resource, tag?: string): PublicationList[];
 
+    setConfig(oi4Id: Oi4Identifier, filter: string, config: IContainerConfig): boolean;
+
     on(event: string, listener: Function): this;
 
-    // Methods
     addDataSet(dataSetName: string, data: IOPCUANetworkMessage, metadata: IOPCUAMetaData): void;
 }
 

--- a/packages/oi4-oec-service-node/tests/Test-utils/Factories/MockedIApplicationResourceFactory.ts
+++ b/packages/oi4-oec-service-node/tests/Test-utils/Factories/MockedIApplicationResourceFactory.ts
@@ -21,6 +21,7 @@ import {
     RTLicense, SubscriptionList
 } from '@oi4/oi4-oec-service-model';
 import {extractProductInstanceUri} from "../../../src/application/OI4Resource";
+import { IContainerConfig } from '@oi4/oi4-oec-service-model';
 
 export class MockedIApplicationResourceFactory {
 
@@ -110,6 +111,9 @@ export class MockedIApplicationResourceFactory {
                     return this.subResources.get(oi4Id.toString());
                 }
                 return this.subResources.values();
+            },
+            setConfig(_: Oi4Identifier, __: string, ___: IContainerConfig): boolean {
+                return true;
             },
             // eslint-disable-next-line @typescript-eslint/naming-convention
             on(_: string, __: Function): IOI4ApplicationResources {

--- a/packages/oi4-oec-service-node/tests/Utilities/Helpers/MqttMessageProcessor.test.ts
+++ b/packages/oi4-oec-service-node/tests/Utilities/Helpers/MqttMessageProcessor.test.ts
@@ -191,9 +191,7 @@ describe('Unit test for MqttMessageProcessor', () => {
             description: undefined
         });
 
-        expect(oi4Application.sendResource).toHaveBeenCalledWith(Resource.CONFIG, undefined, '', defaultFakeFilter, 0, 0);
-        expect(fakeLogFile.length).toBe(2);
-        expect(fakeLogFile[1]).toBe(`Added ${defaultFakeFilter} to config group`);
+        expect(oi4Application.sendResource).toHaveBeenCalledWith(Resource.CONFIG, undefined, defaultFakeAppId.toString(), defaultFakeFilter, 0, 0);
     });
 
     it('extract topic info works - config - if the filter is missing an error is thrown', async () => {

--- a/packages/oi4-oec-service-node/tests/application/OI4Application.test.ts
+++ b/packages/oi4-oec-service-node/tests/application/OI4Application.test.ts
@@ -10,6 +10,7 @@ import {
     SubscriptionListConfig,
     EventCategory,
     Health,
+    IContainerConfig,
     IOI4ApplicationResources,
     License,
     LicenseText,
@@ -238,10 +239,13 @@ const getResourceInfo = (): IOI4ApplicationResources => {
             console.log(`subscriptionList elements make no sense and further specification by the OI4 working group ${oi4Id}, ${resourceType}, ${tag}`);
             return this.subscriptionList;
         },
+        setConfig(_oi4Id: Oi4Identifier, _filter: string, _config: IContainerConfig): boolean {
+            return true;
+        },
         addDataSet(dataSetName: string, data: IOPCUANetworkMessage, metadata: IOPCUAMetaData): void {
             console.log(`function addDataSet called with ${dataSetName} ${data} ${metadata}`);
         }
-    }
+    } as IOI4ApplicationResources;
 }
 
 let defaultOi4ApplicationResources: IOI4ApplicationResources;
@@ -568,25 +572,22 @@ describe('OI4MessageBus test', () => {
         mock.mockRestore();
     });
 
-    it('should add new config and send emit status status via mqtt process', async () => {
-        const status: IOPCUANetworkMessage = getIOPCUANetworkMessage();
+    it('should update config and send emit status status via mqtt process', async () => {
+        const setConfig = getIOPCUANetworkMessage();
 
         defaultOi4ApplicationResources.config['group-a'] = {
             name: {locale: EOPCUALocale.enUS, text: 'text'},
             'config_a': {
-                category: EventCategory.CAT_STATUS_1,
-                number: 1,
-                // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-                // @ts-ignore
-                description: 'fake',
-                origin: defaultOi4ApplicationResources.oi4Id
+                name: {locale: EOPCUALocale.enUS, text: 'config_a'},
+                value: '1000',
+                type: EOPCUABaseDataType.Number
             }
         };
         jest.spyOn(OPCUABuilder.prototype, 'checkTopicPath').mockReturnValue(true);
 
         defaultOi4Application.sendEventStatus = jest.fn();
 
-        await defaultOi4Application.mqttMessageProcess.processMqttMessage(`${defaultTopicPrefix}/${defaultAppId}/${TopicMethods.SET}/${Resource.CONFIG}/${defaultOI4Id}/group-a`, Buffer.from(JSON.stringify(status)), defaultOi4Application.builder, defaultOi4Application);
+        await defaultOi4Application.mqttMessageProcess.processMqttMessage(`${defaultTopicPrefix}/${defaultAppId}/${TopicMethods.SET}/${Resource.CONFIG}/${defaultOI4Id}/group-a`, Buffer.from(JSON.stringify(setConfig)), defaultOi4Application.builder, defaultOi4Application);
 
         expect(defaultOi4Application.sendEventStatus).toHaveBeenCalledWith(new StatusEvent(defaultOi4ApplicationResources.oi4Id.toString(), EOPCUAStatusCode.Good));
         expect(defaultOi4Application.applicationResources).toBe(defaultOi4ApplicationResources);

--- a/packages/oi4-oec-service-node/tests/application/Oi4ApplicationResources.test.ts
+++ b/packages/oi4-oec-service-node/tests/application/Oi4ApplicationResources.test.ts
@@ -1,7 +1,8 @@
 import {OI4ApplicationResources} from '../../src';
+import {OI4ResourceEvent} from '../../src/application/OI4Resource';
 import {MockedIApplicationResourceFactory} from '../Test-utils/Factories/MockedIApplicationResourceFactory';
-import {IMasterAssetModel, Oi4Identifier} from '@oi4/oi4-oec-service-opcua-model';
-import {EDeviceHealth, Health, IOI4Resource, PublicationList, PublicationListMode, PublicationListConfig, Resource} from '@oi4/oi4-oec-service-model';
+import {IMasterAssetModel, Oi4Identifier, EOPCUALocale, EOPCUABaseDataType} from '@oi4/oi4-oec-service-opcua-model';
+import {EDeviceHealth, Health, IContainerConfig, IOI4Resource, PublicationList, PublicationListMode, PublicationListConfig, Resource, IContainerConfigGroupName, IContainerConfigConfigName} from '@oi4/oi4-oec-service-model';
 import fs = require('fs');
 
 describe('Test Oi4ApplicationResources', () => {
@@ -96,6 +97,166 @@ describe('Test Oi4ApplicationResources', () => {
         expect(resources.getPublicationList(resources.oi4Id, Resource.EVENT)).toEqual([]);
         expect(resources.getPublicationList(resources.oi4Id, Resource.DATA, 'wrong')).toEqual([]);
         expect(resources.getPublicationList(resources.oi4Id, Resource.DATA, 'oee')).toContain(publicationList);
+    });
+
+
+    function createConfig(): IContainerConfig {
+        const containerConfig: IContainerConfig = {
+            'group-a': {
+                name: {locale: EOPCUALocale.enUS, text: 'group-a'},
+                'config_a': {
+                    name: {locale: EOPCUALocale.enUS, text: 'config_a'},
+                    value: '2000',
+                    type: EOPCUABaseDataType.Number,
+                    validation: {
+                        min: 0,
+                        max: 2000
+                    }
+                }
+            },
+            'context': {
+                name: {locale: EOPCUALocale.enUS, text: 'filter 1'}}
+        };
+
+        return containerConfig;
+    }
+
+    function createResourceWithConfig(oi4Id: Oi4Identifier): IOI4Resource {
+        const subResource: IOI4Resource = {
+            oi4Id: oi4Id,
+            config: createConfig(),
+            profile: undefined,
+            mam: undefined,
+            health: undefined,
+            license: [],
+            licenseText: undefined,
+            rtLicense: undefined,
+            publicationList: [],
+            subscriptionList: []
+        }
+        
+        return subResource;
+    }
+
+    it ('setConfig updates main configuration', ()=> {
+        resources.config =  createConfig();
+        const setConfig = createConfig();
+        ((setConfig['group-a'] as IContainerConfigGroupName)['config_a'] as IContainerConfigConfigName).value = '1000';
+
+        let receivedOi4Id: Oi4Identifier = undefined;
+        let receivedResource: Resource = undefined;
+        resources.once(OI4ResourceEvent.RESOURCE_CHANGED, (oi4Id: Oi4Identifier, res: Resource)=> {
+            receivedOi4Id = oi4Id;
+            receivedResource = res;
+        })
+
+        const result = resources.setConfig(resources.oi4Id, 'filter%201', setConfig);
+
+        expect(result).toBeTruthy();
+        expect(((resources.config['group-a'] as IContainerConfigGroupName)['config_a'] as IContainerConfigConfigName).value).toBe('1000');
+        expect(receivedOi4Id).toStrictEqual(resources.oi4Id);
+        expect(receivedResource).toBe(Resource.CONFIG);
+    });
+
+    it ('setConfig updates subResource configuration', ()=> {
+        const oi4Identifier = new Oi4Identifier('vendor.com', 'a', 'b', 'c');
+        const subResource = createResourceWithConfig(oi4Identifier);
+        resources.addSubResource(subResource);
+        
+        const setConfig = createConfig();
+        ((setConfig['group-a'] as IContainerConfigGroupName)['config_a'] as IContainerConfigConfigName).value = '1000';
+
+        let receivedOi4Id: Oi4Identifier = undefined;
+        let receivedResource: Resource = undefined;
+        resources.once(OI4ResourceEvent.RESOURCE_CHANGED, (oi4Id: Oi4Identifier, res: Resource)=> {
+            receivedOi4Id = oi4Id;
+            receivedResource = res;
+        })
+
+        const result = resources.setConfig(oi4Identifier, 'filter%201', setConfig);
+
+        expect(result).toBeTruthy();
+        expect(((subResource.config['group-a'] as IContainerConfigGroupName)['config_a'] as IContainerConfigConfigName).value).toBe('1000');
+        expect(receivedOi4Id).toStrictEqual(oi4Identifier);
+        expect(receivedResource).toBe(Resource.CONFIG);
+    });
+
+    it ('setConfig updates nothing if filter is wrong', ()=> {
+        resources.config =  createConfig();
+        const setConfig = createConfig();
+        ((setConfig['group-a'] as IContainerConfigGroupName)['config_a'] as IContainerConfigConfigName).value = '1000';
+
+        let receivedOi4Id: Oi4Identifier = undefined;
+        resources.once(OI4ResourceEvent.RESOURCE_CHANGED, (oi4Id: Oi4Identifier)=> {
+            receivedOi4Id = oi4Id;
+        })
+
+        const result = resources.setConfig(resources.oi4Id, 'WRONG_FILTER', setConfig);
+
+        expect(result).toBeFalsy();
+        expect(((resources.config['group-a'] as IContainerConfigGroupName)['config_a'] as IContainerConfigConfigName).value).toBe('2000');
+        expect(receivedOi4Id).toBe(undefined);
+    });
+
+    it ('setConfig updates nothing if new setting is unknown ', ()=> {
+        resources.config =  createConfig();
+        const setConfig: IContainerConfig = {
+            'group-xyz': {
+                name: {locale: EOPCUALocale.enUS, text: 'group-xyz'},
+                'config_a': {
+                    name: {locale: EOPCUALocale.enUS, text: 'config_a'},
+                    value: '1000',
+                    type: EOPCUABaseDataType.Number
+                }
+            }
+        };
+
+        let receivedOi4Id: Oi4Identifier = undefined;
+        resources.once(OI4ResourceEvent.RESOURCE_CHANGED, (oi4Id: Oi4Identifier)=> {
+            receivedOi4Id = oi4Id;
+        })
+
+        const result = resources.setConfig(resources.oi4Id, 'filter%201', setConfig);
+
+        expect(result).toBeFalsy();
+        expect(((resources.config['group-a'] as IContainerConfigGroupName)['config_a'] as IContainerConfigConfigName).value).toBe('2000');
+        expect(receivedOi4Id).toBe(undefined);
+    });
+
+    it ('setConfig updates nothing if new value is out of range', ()=> {
+        resources.config =  createConfig();
+        const setConfig = createConfig();
+        ((setConfig['group-a'] as IContainerConfigGroupName)['config_a'] as IContainerConfigConfigName).value = '56789';
+
+        let receivedOi4Id: Oi4Identifier = undefined;
+        resources.once(OI4ResourceEvent.RESOURCE_CHANGED, (oi4Id: Oi4Identifier)=> {
+            receivedOi4Id = oi4Id;
+        })
+
+        const result = resources.setConfig(resources.oi4Id, 'filter%201', setConfig);
+
+        expect(result).toBeFalsy();
+        expect(((resources.config['group-a'] as IContainerConfigGroupName)['config_a'] as IContainerConfigConfigName).value).toBe('2000');
+        expect(receivedOi4Id).toBe(undefined);
+    });
+
+
+    it ('setConfig sets main configuration', ()=> {
+        const setConfig = createConfig();
+
+        let receivedOi4Id: Oi4Identifier = undefined;
+        let receivedResource: Resource = undefined;
+        resources.once(OI4ResourceEvent.RESOURCE_ADDED, (oi4Id: Oi4Identifier, res: Resource)=> {
+            receivedOi4Id = oi4Id;
+            receivedResource = res;
+        })
+
+        const result = resources.setConfig(resources.oi4Id, 'filter%201', setConfig);
+
+        expect(result).toBeTruthy();
+        expect(((resources.config['group-a'] as IContainerConfigGroupName)['config_a'] as IContainerConfigConfigName).value).toBe('2000');
+        expect(receivedOi4Id).toStrictEqual(resources.oi4Id);
+        expect(receivedResource).toBe(Resource.CONFIG);
     });
 
 });


### PR DESCRIPTION
## IOI4ApplicationResources
* Added new method `setConfig` that allows to set or update a configuration. This method also emits events `OI4ResourceEvent.RESOURCE_CHANGED` or `OI4ResourceEvent.RESOURCE_CHANGED` in case that the configuration was added or updated.

## MqttMessageProcessor
* Now uses the new method `IOI4ApplicationResources.setConfig` in case that the configuration shall be changed.