### PR TITLE
Allow changing of profile resources without side-effects

### DIFF
--- a/packages/oi4-oec-service-model/src/model/Resource.ts
+++ b/packages/oi4-oec-service-model/src/model/Resource.ts
@@ -174,7 +174,7 @@ export class Profile implements OI4Payload {
     readonly resource: Resource[];
 
     constructor(resource: Resource[]) {
-        this.resource = resource;
+        this.resource = Object.assign([], resource);
     }
 
     resourceType(): Resource {

--- a/packages/oi4-oec-service-model/test/Resource.test.ts
+++ b/packages/oi4-oec-service-model/test/Resource.test.ts
@@ -1,4 +1,4 @@
-import {MasterAssetModel} from '../src';
+import {MasterAssetModel, Profile, Resource} from '../src';
 import {ServiceTypes} from '@oi4/oi4-oec-service-opcua-model';
 
 
@@ -30,5 +30,14 @@ describe('Unit tests for Resources', () => {
         mam.DeviceClass = 'invalid';
         expect(()=> mam.getServiceType()).toThrowError('Unknown service type: invalid');
     });
+
+    it ('changing the profile should not affect the original resource list', ()=> {
+        const resources = [Resource.MAM, Resource.HEALTH];
+        const profile = new Profile(resources);
+        profile.resource.push(Resource.EVENT);
+
+        expect(profile.resource).toEqual([Resource.MAM, Resource.HEALTH, Resource.EVENT]);
+        expect(resources).toEqual([Resource.MAM, Resource.HEALTH]);
+    })
 
 });


### PR DESCRIPTION
Allow modification of the profile-list without changing the array that was used for initialization. This prevents side effects like shown below:
```ts
// OI4Resource constructor
this._profile = new Profile(Application.mandatory);

// some class updates the profile, e.g.
profile.push(Resource.EVENT); // this adds Resource.EVENT to the Application.mandatory list!!!
```