### PR TITLE
Bugfix: Validator uses wrong message for 'get/metadata'

### DIFF
--- a/packages/oi4-oec-service-conformity-validator/src/Helper/MessageBusLookup.ts
+++ b/packages/oi4-oec-service-conformity-validator/src/Helper/MessageBusLookup.ts
@@ -35,7 +35,7 @@ export class MessageBusLookup implements IMessageBusLookup
 
         
         await this.conformityClient.subscribe(pubTopic);
-        await this.conformityClient.publish(getTopic, JSON.stringify(getRequest.Message));
+        await this.conformityClient.publish(getTopic, getRequest.JsonMessage);
 
         return await promiseTimeout(new Promise((resolve) => {
                 this.pubMessages.once(pubTopic, (res) => {

--- a/packages/oi4-oec-service-conformity-validator/src/model/IMessageBusLookup.ts
+++ b/packages/oi4-oec-service-conformity-validator/src/model/IMessageBusLookup.ts
@@ -1,4 +1,3 @@
-import {IOPCUANetworkMessage} from '@oi4/oi4-oec-service-opcua-model';
 import {Resource} from '@oi4/oi4-oec-service-model';
 
 
@@ -7,12 +6,12 @@ export class GetRequest {
     Resource: Resource;
     SubResource? : string;
     Filter?: string;
-    Message: IOPCUANetworkMessage;
+    JsonMessage: string;
 
-    constructor(topicPreamble: string, resource: Resource, message: IOPCUANetworkMessage, subResource?: string, filter?: string) {
+    constructor(topicPreamble: string, resource: Resource, jsonMessage: string, subResource?: string, filter?: string) {
         this.TopicPreamble = topicPreamble;
         this.Resource = resource;
-        this.Message = message;
+        this.JsonMessage = jsonMessage;
         this.SubResource = subResource;
         this.Filter = filter;
     }

--- a/packages/oi4-oec-service-conformity-validator/tests/ConformityValidator.test.ts
+++ b/packages/oi4-oec-service-conformity-validator/tests/ConformityValidator.test.ts
@@ -96,7 +96,8 @@ function getObjectUnderTest(response: ITestData[] = [], fixCorrelationId = true)
 
         if (fixCorrelationId)
         {
-            message.correlationId = request.Message.MessageId;
+            const decodedMessage = JSON.parse(request.JsonMessage);
+            message.correlationId = decodedMessage.MessageId;
         }
 
         return new PubResponse(request.getTopic('pub'), Buffer.from(JSON.stringify(message)));
@@ -307,6 +308,18 @@ describe('Unit test for ConformityValidator ', () => {
 
         expect(result.validity).toBe(EValidity.partial);
         expect(result.resource['metadata'].validity).toBe(EValidity.nok);
+    });
+
+    it ('should validate meta data conformity', async () => {
+
+        const messages: ITestData[] = [
+            {resource: Resource.METADATA, subResource: defaultSubResource, message: metadata_valid},
+        ]
+
+        const objectUnderTest = getObjectUnderTest(messages);
+        const result = await objectUnderTest.checkMetaDataConformity(defaultTopic, defaultSubResource, '');
+        
+        expect(result.validity).toBe(EValidity.ok);
     });
 
     it('should evaluate additional resources not included in the profile' , async ()=> {


### PR DESCRIPTION
A wrong message type (`NetworkMessage` instead of `DataSetMetaData`) was used by the validator when requesting MetaData via `get/metadata`. 