### PR TITLE
Fixed allowed methods

### DIFF
--- a/packages/oi4-oec-json-schemas/src/schemas/constants/method.schema.json
+++ b/packages/oi4-oec-json-schemas/src/schemas/constants/method.schema.json
@@ -3,5 +3,5 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "description": "A list of acceptable methods",
   "type": "string",
-  "enum": ["pub", "get", "set", "del", "req", "res"]
+  "enum": ["pub", "get", "set", "del", "call", "reply"]
 }

--- a/packages/oi4-oec-json-schemas/src/schemas/constants/topicPath.schema.json
+++ b/packages/oi4-oec-json-schemas/src/schemas/constants/topicPath.schema.json
@@ -3,5 +3,5 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "description": "Topic of subscription",
   "type": "string",
-  "pattern": "^oi4\\/(Registry|OTConnector|Utility|Persistence|Aggregation|OOCConnector|ITConnector|\\+|#)\\/(((([a-z0-9-]+\\.)*([a-z0-9-]*))|\\+|#)(?:\\/[^\\/`\\^\r\n]+){3})\\/(pub|get|set|del|req|res|\\+|#)\\/(mam|health|config|license|licenseText|rtLicense|data|metadata|event|profile|publicationList|subscriptionList|referenceDesignation|interfaces|\\+|#)(.*)$"
+  "pattern": "^oi4\\/(Registry|OTConnector|Utility|Persistence|Aggregation|OOCConnector|ITConnector|\\+|#)\\/(((([a-z0-9-]+\\.)*([a-z0-9-]*))|\\+|#)(?:\\/[^\\/`\\^\r\n]+){3})\\/(pub|get|set|del|call|reply|\\+|#)\\/(mam|health|config|license|licenseText|rtLicense|data|metadata|event|profile|publicationList|subscriptionList|referenceDesignation|interfaces|\\+|#)(.*)$"
 }


### PR DESCRIPTION
Fixed: `req` and `res` topic-methods are not allowed according OEC development guideline 1.0.0. Instead `call` and `reply` shall be used.