### PR TITLE
Fixed heartbeat MQTT topic

### DIFF
--- a/packages/oi4-oec-service-node/src/application/OI4Application.ts
+++ b/packages/oi4-oec-service-node/src/application/OI4Application.ts
@@ -172,9 +172,9 @@ export class OI4Application extends EventEmitter implements IOI4Application {
 
     private initClientHealthHeartBeat() {
         setInterval(async () => {
-            await this.sendResource(Resource.HEALTH, '', this.oi4Id.toString(), this.oi4Id.toString()).then();
+            await this.sendResource(Resource.HEALTH, '', this.oi4Id.toString(), '').then();
             for (const resource of this.applicationResources.subResources.values()) {
-                await this.sendResource(Resource.HEALTH, '', resource.oi4Id.toString(), resource.oi4Id.toString()).then();
+                await this.sendResource(Resource.HEALTH, '', resource.oi4Id.toString(), '').then();
             }
         }, this.clientHealthHeartbeatInterval); // send all health messages every 60 seconds!
     }


### PR DESCRIPTION
Fixed wrong MQTT topic for Health heartbeat messages. `sendResource` must be called with an empty filter-argument in this case.

Wrong MQTT topic
![image](https://user-images.githubusercontent.com/103026556/190590367-df5fb9cf-f679-4b10-94a4-ddbe5333370d.png)

