### PR TITLE
Added support for get/mam without subResource

### DIFF
--- a/packages/oi4-oec-service-node/src/Utilities/Helpers/ClientPayloadHelper.ts
+++ b/packages/oi4-oec-service-node/src/Utilities/Helpers/ClientPayloadHelper.ts
@@ -37,10 +37,24 @@ export class ClientPayloadHelper {
         return {abortSending: false, payload: payload};
     }
 
-    createMamResourcePayload(applicationResources: IOI4ApplicationResources, subResource: string): ValidatedPayload {
-        const mam = applicationResources.getMasterAssetModel(Oi4Identifier.fromString(subResource));
-        const payload = [this.createPayload(mam, subResource)];
-        return {abortSending: false, payload: payload};
+    createMamResourcePayload(applicationResources: IOI4ApplicationResources, oi4Id: Oi4Identifier, subResource?: string): ValidatedPayload {
+        if (subResource) { // get mam from a specific asset
+            const mam = applicationResources.getMasterAssetModel(Oi4Identifier.fromString(subResource));
+            const payload = [this.createPayload(mam, subResource)];
+            return {abortSending: false, payload: payload};
+        } else { // get all mam's
+            const oi4Identifiers = [...applicationResources.subResources.keys()];
+            const subResourcesPayloads =  oi4Identifiers.map(id => {
+                const oi4Identifier = Oi4Identifier.fromString(id);
+                const mam = applicationResources.getMasterAssetModel(oi4Identifier);
+                return this.createPayload(mam, id);
+            })
+
+            const mam = applicationResources.getMasterAssetModel(oi4Id);
+            const payload = this.createPayload(mam, oi4Id.toString());
+
+            return {abortSending: false, payload: [payload, ... subResourcesPayloads]};
+        } 
     }
 
     createHealthStatePayload(deviceHealth: EDeviceHealth, score: number): Health {

--- a/packages/oi4-oec-service-node/src/application/OI4Application.ts
+++ b/packages/oi4-oec-service-node/src/application/OI4Application.ts
@@ -270,7 +270,7 @@ export class OI4Application extends EventEmitter implements IOI4Application {
 
         switch (resource) {
             case Resource.MAM:
-                payloadResult = this.clientPayloadHelper.createMamResourcePayload(this.applicationResources, subResource);
+                payloadResult = this.clientPayloadHelper.createMamResourcePayload(this.applicationResources, this.oi4Id, subResource);
                 break;
             case Resource.RT_LICENSE: { // This is the default case, just send the resource if the tag is ok
                 payloadResult = this.clientPayloadHelper.createRTLicenseResourcePayload(this.applicationResources, this.oi4Id);

--- a/packages/oi4-oec-service-node/tests/Utilities/Helpers/ClientPayloadHelper.test.ts
+++ b/packages/oi4-oec-service-node/tests/Utilities/Helpers/ClientPayloadHelper.test.ts
@@ -66,6 +66,13 @@ describe('Unit test for ClientPayloadHelper', () => {
         expect(validatedPayload.payload.length).toBe(0);
     }
 
+    it ('createMamResourcePayload works for main resource', async()=> {
+        const mamPayload = clientPayloadHelper.createMamResourcePayload(mockedOI4ApplicationResources, OI4_ID);
+        expect(mamPayload.payload.length).toBe(1);
+        expect(mamPayload.payload[0].Payload).toBe(mockedOI4ApplicationResources.mam);
+        expect(mamPayload.abortSending).toBe(false);
+    })
+
     it('createLicenseTextSendResourcePayload works when containerState.licenseText[filter] is undefined', async () => {
         const validatedPayload: ValidatedPayload = clientPayloadHelper.createLicenseTextSendResourcePayload(mockedOI4ApplicationResources, 'whatever');
         checkForUndefinedPayload(validatedPayload);


### PR DESCRIPTION
Added support for `.../get/mam` in case that no subResource is provided. In this case all master asset models related to this application shall be published.