### PR TITLE
Fixed Source information

### DIFF
--- a/packages/oi4-oec-service-node/src/messaging/ClientPayloadHelper.ts
+++ b/packages/oi4-oec-service-node/src/messaging/ClientPayloadHelper.ts
@@ -112,7 +112,7 @@ export class ClientPayloadHelper {
                 Source: applicationResources.oi4Id,
                 Payload: {
                     ...elem,
-                    Source: elem.Source
+                    Source: elem.Source.toString()
                 },
             } as IOPCUADataSetMessage;
         });


### PR DESCRIPTION
Fixed wrong Source information. `Source` was:

```JSON
"Source":{"manufacturerUri":"openindustry4.com","model":"OEC-Registry","productCode":"OECREG","serialNumber":"PC-SG-CFZ-1"}"
```

But should be:
```JSON
"Source": "openindustry4.com/OEC-Registry/OECREG/PC-SG-CFZ-1"
```